### PR TITLE
Const cast audit

### DIFF
--- a/src/store/index/Entries.zig
+++ b/src/store/index/Entries.zig
@@ -283,7 +283,7 @@ test "EntriesShard.add" {
             }
         }
 
-        const result = try shard.add(alloc, @constCast(case.test_entries), maxIndexMemBlockSize);
+        const result = try shard.add(alloc, case.test_entries, maxIndexMemBlockSize);
 
         // Check if flush happened as expected
         if (case.expected_flush) {

--- a/src/store/inmem/TimestampsEncoder.zig
+++ b/src/store/inmem/TimestampsEncoder.zig
@@ -33,7 +33,7 @@ pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
 
 // TODO: rename to encodeAlloc, implement 2 methods as replacement: bound and encode.
 // the purpose is to being able to reuse a buffer across encodings
-pub fn encode(self: *Self, allocator: std.mem.Allocator, tss: []u64) !EncodedTimestamps {
+pub fn encode(self: *Self, allocator: std.mem.Allocator, tss: []const u64) !EncodedTimestamps {
     const len: u32 = @intCast(tss.len);
 
     const compress_buf = try allocator.alloc(u8, zType.deltapack_compress_bound(len));
@@ -66,7 +66,7 @@ test "TimestampsEncoder" {
         const enc = try Self.init(alloc);
         defer enc.deinit(alloc);
 
-        const res = try enc.encode(alloc, @constCast(case.input));
+        const res = try enc.encode(alloc, case.input);
         defer alloc.free(res.buf);
         try std.testing.expectEqual(EncodingType.ZDeltapack, res.encodingType);
 

--- a/src/store/inmem/bloom.zig
+++ b/src/store/inmem/bloom.zig
@@ -37,7 +37,7 @@ pub const HashTokenizer = struct {
     pub fn tokenizeValues(
         self: *HashTokenizer,
         allocator: std.mem.Allocator,
-        values: [][]const u8,
+        values: []const []const u8,
     ) !std.ArrayList(u64) {
         var dst: std.ArrayList(u64) = try std.ArrayList(u64).initCapacity(allocator, 2);
         errdefer dst.deinit(allocator);
@@ -209,7 +209,7 @@ test "tokenizeValues" {
         const tokenizer = try HashTokenizer.init(allocator);
         defer tokenizer.deinit(allocator);
 
-        var tokens = try tokenizer.tokenizeValues(allocator, @constCast(c.input));
+        var tokens = try tokenizer.tokenizeValues(allocator, c.input);
         defer tokens.deinit(allocator);
 
         try std.testing.expectEqualSlices(u64, c.expected, tokens.items);
@@ -400,7 +400,7 @@ test "BloomFilter" {
         // init
         var tokenizer = try HashTokenizer.init(allocator);
         defer tokenizer.deinit(allocator);
-        var hashes = try tokenizer.tokenizeValues(allocator, @constCast(case.tokens));
+        var hashes = try tokenizer.tokenizeValues(allocator, case.tokens);
         defer hashes.deinit(allocator);
 
         const bf = try BloomFilter.initHashes(allocator, hashes.items);

--- a/src/store/inmem/reader.zig
+++ b/src/store/inmem/reader.zig
@@ -154,7 +154,7 @@ pub const StreamReader = struct {
 
         var columnIDGen: *ColumnIDGen = undefined;
         if (columnsKeysBuf.len > 0) {
-            columnIDGen = try ColumnIDGen.decode(alloc, @constCast(columnsKeysBuf));
+            columnIDGen = try ColumnIDGen.decode(alloc, columnsKeysBuf);
         } else {
             columnIDGen = try ColumnIDGen.init(alloc);
         }

--- a/src/store/inmem/reader.zig
+++ b/src/store/inmem/reader.zig
@@ -215,9 +215,8 @@ pub const StreamReader = struct {
         }
         self.bloomTokensList.deinit(allocator);
 
-        // TODO: audit and get rid of all @constCast
-        allocator.free(@constCast(self.columnsKeysBuf));
-        allocator.free(@constCast(self.columnIdxsBuf));
+        allocator.free(self.columnsKeysBuf);
+        allocator.free(self.columnIdxsBuf);
 
         const columnIDGen = @constCast(self.columnIDGen);
         columnIDGen.deinit(allocator);

--- a/src/store/inmem/reader.zig
+++ b/src/store/inmem/reader.zig
@@ -33,8 +33,8 @@ pub const StreamReader = struct {
     bloomTokensList: std.ArrayList([]const u8),
 
     // TODO: decode manually when it comes to file reader
-    columnIDGen: *const ColumnIDGen,
-    colIdx: *const std.AutoHashMap(u16, u16),
+    columnIDGen: *ColumnIDGen,
+    colIdx: *std.AutoHashMap(u16, u16),
 
     // TODO: this flag doesn't look smart,
     // there must be a better idea to track ownership
@@ -218,12 +218,10 @@ pub const StreamReader = struct {
         allocator.free(self.columnsKeysBuf);
         allocator.free(self.columnIdxsBuf);
 
-        const columnIDGen = @constCast(self.columnIDGen);
-        columnIDGen.deinit(allocator);
+        self.columnIDGen.deinit(allocator);
 
-        const colIdx = @constCast(self.colIdx);
-        colIdx.deinit();
-        allocator.destroy(colIdx);
+        self.colIdx.deinit();
+        allocator.destroy(self.colIdx);
 
         allocator.destroy(self);
     }


### PR DESCRIPTION
Aims to solve https://github.com/ochi-team/ochi/issues/95

Solved some easy ones. :)

There are lots of test cases that use `@constCast`, I get the idea behind them, though I think the approach can be improved. The casts are there because Zig insists that variables are explicitly stack allocated. I'll figure out some improvements shortly.

See individual commits.