### PR TITLE
optimize Store.addLines for hot path

### DIFF
--- a/src/Store.zig
+++ b/src/Store.zig
@@ -180,7 +180,7 @@ pub fn addLines(
         self.partitionsMx.lock();
         defer self.partitionsMx.unlock();
 
-        const partition = try self.getLruOrPartition(allocator, first_day);
+        const partition = try self.getPartitionOrLru(allocator, first_day);
         defer partition.release();
         try partition.addLines(allocator, list, tags, encodedTags);
 
@@ -219,7 +219,7 @@ pub fn addLines(
         self.partitionsMx.lock();
         defer self.partitionsMx.unlock();
 
-        const partition = try self.getLruOrPartition(allocator, day);
+        const partition = try self.getPartitionOrLru(allocator, day);
         defer partition.release();
         try partition.addLines(allocator, it.value_ptr.*, tags, encodedTags);
     }
@@ -343,7 +343,7 @@ fn getPartition(self: *Store, alloc: Allocator, day: u32) !*Partition {
     return part;
 }
 
-fn getLruOrPartition(self: *Store, alloc: Allocator, day: u32) !*Partition {
+fn getPartitionOrLru(self: *Store, alloc: Allocator, day: u32) !*Partition {
     if (self.getLruPartition()) |part|
         if (part.day == day)
             return part;

--- a/src/Store.zig
+++ b/src/Store.zig
@@ -146,6 +146,7 @@ pub fn addLines(
     tags: []Field,
     encodedTags: []const u8,
 ) !void {
+    if (lines.len == 0) return;
     // TODO: make partition interval configurable
     // in order to being able to test shorter partitions: 1, 2, 3, 6, 12 hours
     const nowNs: u64 = @intCast(std.time.nanoTimestamp());
@@ -154,10 +155,45 @@ pub fn addLines(
     // in case an ingestor sends data with broken timezone or timestamp
     const maxDay = (nowNs + std.time.ns_per_day) / std.time.ns_per_day;
 
+    var idx: usize = 0;
+    // Hot path if all Lines belong to the same day
+    {
+        var list = std.ArrayList(Line).empty;
+
+        const first_day: u32 = @intCast(lines[0].timestampNs / std.time.ns_per_day);
+
+        while (idx < lines.len) : (idx += 1) {
+            const day: u32 = @intCast(lines[idx].timestampNs / std.time.ns_per_day);
+            if (day < minDay) {
+                // TODO: log a warning
+                continue;
+            }
+            if (day > maxDay) {
+                // TODO: log a warning
+                continue;
+            }
+            if (day != first_day) break;
+
+            try list.append(allocator, lines[idx]);
+        }
+
+        self.partitionsMx.lock();
+        defer self.partitionsMx.unlock();
+
+        const partition = try self.getLruOrPartition(allocator, first_day);
+        defer partition.release();
+        try partition.addLines(allocator, list, tags, encodedTags);
+
+        // Early return
+        if (idx == lines.len) return;
+    }
+
+    // If the Lines belong to different Partitions, continue where left off,
+    // sort them by day, then bulk add
     var linesByInterval = std.AutoHashMap(u32, std.ArrayList(Line)).init(allocator);
 
-    for (lines) |line| {
-        const day: u32 = @intCast(line.timestampNs / std.time.ns_per_day);
+    while (idx < lines.len) : (idx += 1) {
+        const day: u32 = @intCast(lines[idx].timestampNs / std.time.ns_per_day);
         if (day < minDay) {
             // TODO: log a warning
             continue;
@@ -167,36 +203,23 @@ pub fn addLines(
             continue;
         }
 
-        if (linesByInterval.getPtr(day)) |list| {
-            try list.append(allocator, line);
-            continue;
+        const gop = try linesByInterval.getOrPut(day);
+        if (gop.found_existing) {
+            try gop.value_ptr.append(allocator, lines[idx]);
+        } else {
+            gop.value_ptr.* = .empty;
+            try gop.value_ptr.append(allocator, lines[idx]);
         }
-        var list = std.ArrayList(Line).empty;
-        try list.append(allocator, line);
-        try linesByInterval.put(day, list);
     }
 
     var linesIterator = linesByInterval.iterator();
     while (linesIterator.next()) |it| {
         const day = it.key_ptr.*;
 
-        // TODO: rework how we approach lru partition
-        // 1. pass all the lines directly to the store,
-        // iterate over saving the window width, if it fits - pass them all to the lru
-        // 2. if it doesn't fit - make a map by intervals, retain it.
-        // Ref counter here makes no sense, but it demos the API is necessary to perform after rework
-
         self.partitionsMx.lock();
         defer self.partitionsMx.unlock();
 
-        const lruPartition = self.getLruPartition();
-        if (lruPartition) |part| if (part.day == day) {
-            defer part.release();
-            try part.addLines(allocator, it.value_ptr.*, tags, encodedTags);
-            continue;
-        };
-
-        const partition = try self.getPartition(allocator, day);
+        const partition = try self.getLruOrPartition(allocator, day);
         defer partition.release();
         try partition.addLines(allocator, it.value_ptr.*, tags, encodedTags);
     }
@@ -318,6 +341,14 @@ fn getPartition(self: *Store, alloc: Allocator, day: u32) !*Partition {
 
     self.lruPartition = part;
     return part;
+}
+
+fn getLruOrPartition(self: *Store, alloc: Allocator, day: u32) !*Partition {
+    if (self.getLruPartition()) |part|
+        if (part.day == day)
+            return part;
+
+    return self.getPartition(alloc, day);
 }
 
 // TODO: when we get rid of pathsBuf we can path only partitions ref,

--- a/src/Store.zig
+++ b/src/Store.zig
@@ -161,7 +161,7 @@ pub fn addLines(
     {
         var list = std.ArrayList(Line).empty;
 
-        const first_day: u32 = @intCast(lines[0].timestampNs / std.time.ns_per_day);
+        const firstDay: u32 = @intCast(lines[0].timestampNs / std.time.ns_per_day);
 
         while (idx < lines.len) : (idx += 1) {
             const day: u32 = @intCast(lines[idx].timestampNs / std.time.ns_per_day);
@@ -173,7 +173,7 @@ pub fn addLines(
                 // TODO: log a warning
                 continue;
             }
-            if (day != first_day) break;
+            if (day != firstDay) break;
 
             try list.append(allocator, lines[idx]);
         }
@@ -181,7 +181,7 @@ pub fn addLines(
         self.partitionsMx.lock();
         defer self.partitionsMx.unlock();
 
-        const partition = try self.getPartitionOrLru(allocator, first_day);
+        const partition = try self.getPartitionOrLru(allocator, firstDay);
         defer partition.release();
         try partition.addLines(allocator, list, tags, encodedTags);
 

--- a/src/Store.zig
+++ b/src/Store.zig
@@ -157,7 +157,7 @@ pub fn addLines(
     const maxDay = (nowNs + std.time.ns_per_day) / std.time.ns_per_day;
 
     var idx: usize = 0;
-    // Hot path if all Lines belong to the same day
+    // Hot path if all Lines belong to the same Partition
     {
         var list = std.ArrayList(Line).empty;
 
@@ -177,15 +177,17 @@ pub fn addLines(
 
             try list.append(allocator, lines[idx]);
         }
+        const partition = blk: {
+            self.partitionsMx.lock();
+            defer self.partitionsMx.unlock();
 
-        self.partitionsMx.lock();
-        defer self.partitionsMx.unlock();
-
-        const partition = try self.getPartitionOrLru(allocator, firstDay);
+            break :blk try self.getPartitionOrLru(allocator, firstDay);
+        };
         defer partition.release();
+
         try partition.addLines(allocator, list, tags, encodedTags);
 
-        // Early return
+        // Return early since all lines are added to the same Partition
         if (idx == lines.len) return;
     }
 
@@ -217,11 +219,14 @@ pub fn addLines(
     while (linesIterator.next()) |it| {
         const day = it.key_ptr.*;
 
-        self.partitionsMx.lock();
-        defer self.partitionsMx.unlock();
+        const partition = blk: {
+            self.partitionsMx.lock();
+            defer self.partitionsMx.unlock();
 
-        const partition = try self.getPartitionOrLru(allocator, day);
+            break :blk try self.getPartitionOrLru(allocator, day);
+        };
         defer partition.release();
+
         try partition.addLines(allocator, it.value_ptr.*, tags, encodedTags);
     }
 }

--- a/src/Store.zig
+++ b/src/Store.zig
@@ -66,6 +66,7 @@ pub fn init(alloc: Allocator, path: []const u8) !*Store {
         .partitions = partitions,
         .streamCache = streamCache,
     };
+    errdefer alloc.destroy(store);
 
     // TODO: try making it parallel, it speed up start up time
     var it = partitionsDir.iterate();


### PR DESCRIPTION
Optimized the `addLines` function to firstly assume all Lines belong to the same partition. If not, fall back to hash map approach of sorting lines in buckets and then adding them in bulk to appropriate partitions.