### PR TITLE
Manage Recorder workers on startup

### DIFF
--- a/src/DataRecorder.zig
+++ b/src/DataRecorder.zig
@@ -180,6 +180,8 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8, runtime: *Runtime) !*Dat
         .runtime = runtime,
     };
 
+    try t.start(io, alloc);
+
     return t;
 }
 
@@ -941,7 +943,6 @@ test "flushDataShards non-force respects flush deadline" {
 
     const recorder = try DataRecorder.init(io, alloc, rootPath, runtime);
     defer recorder.deinit(io, alloc);
-    try recorder.start(io, alloc);
 
     try recorder.stop(io, alloc);
 
@@ -976,7 +977,6 @@ test "mergeTables force single mem table creates disk table" {
 
     const recorder = try DataRecorder.init(io, alloc, rootPath, runtime);
     defer recorder.deinit(io, alloc);
-    try recorder.start(io, alloc);
 
     try recorder.stop(io, alloc);
 
@@ -1014,7 +1014,6 @@ test "DataRecorder.addAndReopenPreservesLineCount" {
 
         const recorder = try DataRecorder.init(io, alloc, rootPath, runtime);
         defer recorder.deinit(io, alloc);
-        try recorder.start(io, alloc);
 
         for (0..inserted) |i| {
             var batch = [_]Line{stableLine(@intCast(i + 1), 1, i)};
@@ -1036,8 +1035,6 @@ test "DataRecorder.addAndReopenPreservesLineCount" {
 
         const reopened = try DataRecorder.init(io, alloc, rootPath, runtime);
         defer reopened.deinit(io, alloc);
-
-        try reopened.start(io, alloc);
 
         try reopened.stop(io, alloc);
 

--- a/src/DataRecorder.zig
+++ b/src/DataRecorder.zig
@@ -180,22 +180,24 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8, runtime: *Runtime) !*Dat
         .runtime = runtime,
     };
 
-    errdefer t.stopped.store(true, .release);
-
-    for (0..concurrency) |_| {
-        try t.startDiskTablesMerge(io, alloc);
-    }
-
-    // TODO: remove background tasks from init to make unit tests real units
-    try t.startMemTablesFlusher(io, alloc);
-    try t.startDataShardsFlusher(io, alloc);
-
     return t;
 }
 
 pub fn createDir(io: Io, path: []const u8) void {
     fs.createDirAssert(io, path);
     fs.syncPathAndParentDir(io, path);
+}
+
+pub fn start(self: *DataRecorder, io: Io, alloc: Allocator) !void {
+    errdefer self.stopped.store(true, .release);
+
+    for (0..self.concurrency) |_| {
+        try self.startDiskTablesMerge(io, alloc);
+    }
+
+    // TODO: remove background tasks from init to make unit tests real units
+    try self.startMemTablesFlusher(io, alloc);
+    try self.startDataShardsFlusher(io, alloc);
 }
 
 // TODO: find an approach to make it never fail,
@@ -207,7 +209,6 @@ pub fn createDir(io: Io, path: []const u8) void {
 // either lock stop or find another way to make sure none of the task are running after wg.wait
 pub fn stop(self: *DataRecorder, io: Io, alloc: Allocator) !void {
     self.stopped.store(true, .release);
-    defer self.deinit(io, alloc);
 
     try self.g.await(io);
 
@@ -717,11 +718,11 @@ fn selectTablesInRange(
     alloc: Allocator,
     dst: *std.ArrayList(*Table),
     tables: []const *Table,
-    start: u64,
+    start_: u64,
     end: u64,
 ) !void {
     for (tables) |table| {
-        if (table.tableHeader.maxTimestamp < start or table.tableHeader.minTimestamp > end) {
+        if (table.tableHeader.maxTimestamp < start_ or table.tableHeader.minTimestamp > end) {
             continue;
         }
         table.retain();
@@ -938,8 +939,9 @@ test "flushDataShards non-force respects flush deadline" {
 
     const recorder = try DataRecorder.init(io, alloc, rootPath, runtime);
     defer recorder.deinit(io, alloc);
-    recorder.stopped.store(true, .release);
-    try recorder.g.await(io);
+    try recorder.start(io, alloc);
+
+    try recorder.stop(io, alloc);
 
     const line = stableLine(1, 1, 0);
     try recorder.shards[0].lines.append(alloc, line);
@@ -972,8 +974,9 @@ test "mergeTables force single mem table creates disk table" {
 
     const recorder = try DataRecorder.init(io, alloc, rootPath, runtime);
     defer recorder.deinit(io, alloc);
-    recorder.stopped.store(true, .release);
-    try recorder.g.await(io);
+    try recorder.start(io, alloc);
+
+    try recorder.stop(io, alloc);
 
     var lines = [_]Line{
         stableLine(1, 1, 0),
@@ -1009,14 +1012,14 @@ test "DataRecorder.addAndReopenPreservesLineCount" {
 
         const recorder = try DataRecorder.init(io, alloc, rootPath, runtime);
         defer recorder.deinit(io, alloc);
+        try recorder.start(io, alloc);
 
         for (0..inserted) |i| {
             var batch = [_]Line{stableLine(@intCast(i + 1), 1, i)};
             try recorder.addLines(io, alloc, batch[0..]);
         }
 
-        recorder.stopped.store(true, .release);
-        try recorder.g.await(io);
+        try recorder.stop(io, alloc);
         try recorder.flushForce(io, alloc);
 
         try testing.expectEqual(@as(usize, 0), recorder.memTables.items.len);
@@ -1031,8 +1034,10 @@ test "DataRecorder.addAndReopenPreservesLineCount" {
 
         const reopened = try DataRecorder.init(io, alloc, rootPath, runtime);
         defer reopened.deinit(io, alloc);
-        reopened.stopped.store(true, .release);
-        try reopened.g.await(io);
+
+        try reopened.start(io, alloc);
+
+        try reopened.stop(io, alloc);
 
         try testing.expect(reopened.diskTables.items.len > 0);
         try testing.expectEqual(0, countMemLinesInRecorder(reopened));

--- a/src/DataRecorder.zig
+++ b/src/DataRecorder.zig
@@ -174,8 +174,6 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8, runtime: *Runtime) !*Dat
         .memMergeSem = .{
             .permits = @max(4, concurrency),
         },
-
-        .stopped = std.atomic.Value(bool).init(false),
         .path = path,
         .runtime = runtime,
     };

--- a/src/DataRecorder.zig
+++ b/src/DataRecorder.zig
@@ -127,7 +127,7 @@ memTablesSem: Io.Semaphore = .{
 // the idea is to test every break on stop.load() similar to check all allocations failure
 g: Io.Group = .init,
 // TODO: migrate to io cancelation
-stopped: std.atomic.Value(bool) = .init(false),
+stopped: std.atomic.Value(bool) = .init(true),
 mergeIdx: std.atomic.Value(usize),
 path: []const u8,
 runtime: *Runtime,
@@ -189,6 +189,8 @@ pub fn createDir(io: Io, path: []const u8) void {
 }
 
 pub fn start(self: *DataRecorder, io: Io, alloc: Allocator) !void {
+    self.stopped.store(false, .release);
+
     errdefer self.stopped.store(true, .release);
 
     for (0..self.concurrency) |_| {

--- a/src/DataRecorder.zig
+++ b/src/DataRecorder.zig
@@ -180,8 +180,6 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8, runtime: *Runtime) !*Dat
         .runtime = runtime,
     };
 
-    try t.start(io, alloc);
-
     return t;
 }
 
@@ -199,7 +197,6 @@ pub fn start(self: *DataRecorder, io: Io, alloc: Allocator) !void {
         try self.startDiskTablesMerge(io, alloc);
     }
 
-    // TODO: remove background tasks from init to make unit tests real units
     try self.startMemTablesFlusher(io, alloc);
     try self.startDataShardsFlusher(io, alloc);
 }
@@ -213,8 +210,14 @@ pub fn start(self: *DataRecorder, io: Io, alloc: Allocator) !void {
 // either lock stop or find another way to make sure none of the task are running after wg.wait
 pub fn stop(self: *DataRecorder, io: Io, alloc: Allocator) !void {
     self.stopped.store(true, .release);
+    defer self.deinit(io, alloc);
 
-    try self.g.await(io);
+    // we ignore canceled erorr, we stop anyway
+    self.g.await(io) catch |err| {
+        switch (err) {
+            error.Canceled => {},
+        }
+    };
 
     try self.flushForce(io, alloc);
 }
@@ -944,8 +947,6 @@ test "flushDataShards non-force respects flush deadline" {
     const recorder = try DataRecorder.init(io, alloc, rootPath, runtime);
     defer recorder.deinit(io, alloc);
 
-    try recorder.stop(io, alloc);
-
     const line = stableLine(1, 1, 0);
     try recorder.shards[0].lines.append(alloc, line);
     recorder.shards[0].size = line.fieldsSize();
@@ -977,8 +978,6 @@ test "mergeTables force single mem table creates disk table" {
 
     const recorder = try DataRecorder.init(io, alloc, rootPath, runtime);
     defer recorder.deinit(io, alloc);
-
-    try recorder.stop(io, alloc);
 
     var lines = [_]Line{
         stableLine(1, 1, 0),
@@ -1020,7 +1019,6 @@ test "DataRecorder.addAndReopenPreservesLineCount" {
             try recorder.addLines(io, alloc, batch[0..]);
         }
 
-        try recorder.stop(io, alloc);
         try recorder.flushForce(io, alloc);
 
         try testing.expectEqual(@as(usize, 0), recorder.memTables.items.len);
@@ -1035,8 +1033,6 @@ test "DataRecorder.addAndReopenPreservesLineCount" {
 
         const reopened = try DataRecorder.init(io, alloc, rootPath, runtime);
         defer reopened.deinit(io, alloc);
-
-        try reopened.stop(io, alloc);
 
         try testing.expect(reopened.diskTables.items.len > 0);
         try testing.expectEqual(0, countMemLinesInRecorder(reopened));

--- a/src/Partition.zig
+++ b/src/Partition.zig
@@ -85,6 +85,7 @@ pub fn open(
 
     const data = try DataRecorder.init(io, alloc, dataPath, runtime);
     errdefer data.deinit(io, alloc);
+    try data.start(io, alloc);
 
     const partition = try alloc.create(Partition);
     errdefer alloc.destroy(partition);
@@ -105,13 +106,13 @@ pub fn retain(self: *Partition) void {
     _ = self.refCounter.fetchAdd(1, .acquire);
 }
 
-pub fn release(self: *Partition, io: Io) void {
+pub fn release(self: *Partition, io: Io, alloc: Allocator) void {
     const prev = self.refCounter.fetchSub(1, .acq_rel);
     std.debug.assert(prev > 0);
 
     if (prev != 1) return;
 
-    self.close(io);
+    self.close(io, alloc);
 
     // TODO: deletion of the partition due to retention or eviction policy
     // read table release implementation as a sample
@@ -120,12 +121,15 @@ pub fn release(self: *Partition, io: Io) void {
 pub fn close(
     self: *Partition,
     io: Io,
+    alloc: Allocator,
 ) void {
-    self.index.deinit(io, self.alloc);
+    self.index.deinit(io, alloc);
 
-    self.data.stop(io, self.alloc) catch |err| {
+    self.data.stop(io, alloc) catch |err| {
         std.debug.panic("failed to stop data recorder in partition close: {s}", .{@errorName(err)});
     };
+    self.data.deinit(io, alloc);
+
     self.alloc.destroy(self);
 }
 

--- a/src/Partition.zig
+++ b/src/Partition.zig
@@ -81,10 +81,19 @@ pub fn open(
     errdefer indexRecorder.deinit(io, alloc);
 
     const index = try Index.init(alloc, indexRecorder);
+    // index stops recorder too
+    // TODO: this makes reading more complicated than it should be,
+    // ideally it's inits data and defer stops it, same as the data recorder,
+    // the pattern repeats it in the partition everywhere
     errdefer index.deinit(io, alloc);
+    try index.recorder.start(io, alloc);
 
     const data = try DataRecorder.init(io, alloc, dataPath, runtime);
-    errdefer data.deinit(io, alloc);
+    errdefer data.stop(io, alloc) catch |err| {
+        std.debug.print("failed to stop data recorder in partition opening: {s}", .{@errorName(err)});
+    };
+
+    try data.start(io, alloc);
 
     const partition = try alloc.create(Partition);
     errdefer alloc.destroy(partition);
@@ -122,12 +131,9 @@ pub fn close(
     io: Io,
 ) void {
     self.index.deinit(io, self.alloc);
-
     self.data.stop(io, self.alloc) catch |err| {
         std.debug.panic("failed to stop data recorder in partition close: {s}", .{@errorName(err)});
     };
-    self.data.deinit(io, self.alloc);
-
     self.alloc.destroy(self);
 }
 

--- a/src/Partition.zig
+++ b/src/Partition.zig
@@ -106,13 +106,13 @@ pub fn retain(self: *Partition) void {
     _ = self.refCounter.fetchAdd(1, .acquire);
 }
 
-pub fn release(self: *Partition, io: Io, alloc: Allocator) void {
+pub fn release(self: *Partition, io: Io) void {
     const prev = self.refCounter.fetchSub(1, .acq_rel);
     std.debug.assert(prev > 0);
 
     if (prev != 1) return;
 
-    self.close(io, alloc);
+    self.close(io);
 
     // TODO: deletion of the partition due to retention or eviction policy
     // read table release implementation as a sample
@@ -121,14 +121,13 @@ pub fn release(self: *Partition, io: Io, alloc: Allocator) void {
 pub fn close(
     self: *Partition,
     io: Io,
-    alloc: Allocator,
 ) void {
-    self.index.deinit(io, alloc);
+    self.index.deinit(io, self.alloc);
 
-    self.data.stop(io, alloc) catch |err| {
+    self.data.stop(io, self.alloc) catch |err| {
         std.debug.panic("failed to stop data recorder in partition close: {s}", .{@errorName(err)});
     };
-    self.data.deinit(io, alloc);
+    self.data.deinit(io, self.alloc);
 
     self.alloc.destroy(self);
 }

--- a/src/Partition.zig
+++ b/src/Partition.zig
@@ -85,7 +85,6 @@ pub fn open(
 
     const data = try DataRecorder.init(io, alloc, dataPath, runtime);
     errdefer data.deinit(io, alloc);
-    try data.start(io, alloc);
 
     const partition = try alloc.create(Partition);
     errdefer alloc.destroy(partition);

--- a/src/Store.zig
+++ b/src/Store.zig
@@ -68,7 +68,7 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8) !Store {
     var partitions = try std.ArrayList(*Partition).initCapacity(alloc, 30);
     errdefer {
         for (partitions.items) |partition| {
-            partition.close(io);
+            partition.close(io, alloc);
         }
         partitions.deinit(alloc);
     }
@@ -108,7 +108,7 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8) !Store {
 
 pub fn deinit(self: *Store, io: Io, allocator: Allocator) void {
     for (self.partitions.items) |partition| {
-        partition.release(io);
+        partition.release(io, allocator);
     }
     self.partitions.deinit(allocator);
 
@@ -192,7 +192,7 @@ pub fn addLines(
 
             break :blk try self.getPartitionOrLru(io, allocator, firstDay);
         };
-        defer partition.release(io);
+        defer partition.release(io, allocator);
 
         var list = std.ArrayList(Line).initBuffer(lines[0..idx]);
         list.items.len = idx;
@@ -242,7 +242,7 @@ pub fn addLines(
 
             break :blk try self.getPartitionOrLru(io, allocator, day);
         };
-        defer partition.release(io);
+        defer partition.release(io, allocator);
 
         try partition.addLines(io, allocator, it.value_ptr.*, tags, encodedTags);
     }
@@ -272,7 +272,7 @@ pub fn queryLines(
         return err;
     };
     defer {
-        for (parts.items) |part| part.release(io);
+        for (parts.items) |part| part.release(io, alloc);
         parts.deinit(fbaAlloc);
     }
     for (slice) |part| {
@@ -295,7 +295,7 @@ pub fn queryLines(
 pub fn flush(self: *Store, io: Io, alloc: Allocator) !void {
     var parts = try std.ArrayList(*Partition).initCapacity(alloc, self.partitions.items.len);
     defer {
-        for (parts.items) |part| part.release(io);
+        for (parts.items) |part| part.release(io, alloc);
         parts.deinit(alloc);
     }
 
@@ -782,19 +782,19 @@ test "getPartition reuses partition, updates lru, deinit closes partitions and r
     try testing.expectEqual(0, store.partitions.items.len);
 
     const first = try store.getPartition(io, alloc, dayOne);
-    defer first.release(io);
+    defer first.release(io, alloc);
     try testing.expectEqual(1, store.partitions.items.len);
     try testing.expectEqual(first, store.partitions.items[0]);
     try testing.expectEqual(first, store.lruPartition.?);
 
     const firstAgain = try store.getPartition(io, alloc, dayOne);
-    defer firstAgain.release(io);
+    defer firstAgain.release(io, alloc);
     try testing.expectEqual(first, firstAgain);
     try testing.expectEqual(1, store.partitions.items.len);
     try testing.expectEqual(first, store.lruPartition.?);
 
     const second = try store.getPartition(io, alloc, dayTwo);
-    defer second.release(io);
+    defer second.release(io, alloc);
     try testing.expectEqual(2, store.partitions.items.len);
     try testing.expectEqual(second, store.partitions.items[1]);
     try testing.expectEqual(second, store.lruPartition.?);

--- a/src/Store.zig
+++ b/src/Store.zig
@@ -68,7 +68,7 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8) !Store {
     var partitions = try std.ArrayList(*Partition).initCapacity(alloc, 30);
     errdefer {
         for (partitions.items) |partition| {
-            partition.close(io, alloc);
+            partition.close(io);
         }
         partitions.deinit(alloc);
     }
@@ -108,7 +108,7 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8) !Store {
 
 pub fn deinit(self: *Store, io: Io, allocator: Allocator) void {
     for (self.partitions.items) |partition| {
-        partition.release(io, allocator);
+        partition.release(io);
     }
     self.partitions.deinit(allocator);
 
@@ -192,7 +192,7 @@ pub fn addLines(
 
             break :blk try self.getPartitionOrLru(io, allocator, firstDay);
         };
-        defer partition.release(io, allocator);
+        defer partition.release(io);
 
         var list = std.ArrayList(Line).initBuffer(lines[0..idx]);
         list.items.len = idx;
@@ -242,7 +242,7 @@ pub fn addLines(
 
             break :blk try self.getPartitionOrLru(io, allocator, day);
         };
-        defer partition.release(io, allocator);
+        defer partition.release(io);
 
         try partition.addLines(io, allocator, it.value_ptr.*, tags, encodedTags);
     }
@@ -272,7 +272,7 @@ pub fn queryLines(
         return err;
     };
     defer {
-        for (parts.items) |part| part.release(io, alloc);
+        for (parts.items) |part| part.release(io);
         parts.deinit(fbaAlloc);
     }
     for (slice) |part| {
@@ -295,7 +295,7 @@ pub fn queryLines(
 pub fn flush(self: *Store, io: Io, alloc: Allocator) !void {
     var parts = try std.ArrayList(*Partition).initCapacity(alloc, self.partitions.items.len);
     defer {
-        for (parts.items) |part| part.release(io, alloc);
+        for (parts.items) |part| part.release(io);
         parts.deinit(alloc);
     }
 
@@ -782,19 +782,19 @@ test "getPartition reuses partition, updates lru, deinit closes partitions and r
     try testing.expectEqual(0, store.partitions.items.len);
 
     const first = try store.getPartition(io, alloc, dayOne);
-    defer first.release(io, alloc);
+    defer first.release(io);
     try testing.expectEqual(1, store.partitions.items.len);
     try testing.expectEqual(first, store.partitions.items[0]);
     try testing.expectEqual(first, store.lruPartition.?);
 
     const firstAgain = try store.getPartition(io, alloc, dayOne);
-    defer firstAgain.release(io, alloc);
+    defer firstAgain.release(io);
     try testing.expectEqual(first, firstAgain);
     try testing.expectEqual(1, store.partitions.items.len);
     try testing.expectEqual(first, store.lruPartition.?);
 
     const second = try store.getPartition(io, alloc, dayTwo);
-    defer second.release(io, alloc);
+    defer second.release(io);
     try testing.expectEqual(2, store.partitions.items.len);
     try testing.expectEqual(second, store.partitions.items[1]);
     try testing.expectEqual(second, store.lruPartition.?);

--- a/src/store/index/Index.zig
+++ b/src/store/index/Index.zig
@@ -42,7 +42,7 @@ pub fn init(allocator: std.mem.Allocator, recorder: *IndexRecorder) !*Self {
 
 pub fn deinit(self: *Self, io: Io, allocator: Allocator) void {
     self.recorder.stop(io, allocator) catch |err| {
-        std.debug.panic("failed to stop index recorder in partition close: {s}", .{@errorName(err)});
+        std.debug.print("failed to stop index recorder in partition close: {s}", .{@errorName(err)});
     };
 
     allocator.destroy(self);

--- a/src/store/index/IndexRecorder.zig
+++ b/src/store/index/IndexRecorder.zig
@@ -137,29 +137,32 @@ pub fn init(io: Io, alloc: Allocator, path: []const u8, runtime: *Runtime) !*Ind
         },
     };
 
-    // the allocator is different from http life cycle,
-    // but shared between all the background jobs
-    // TODO: find a better allocator, perhaps an arena with regular reset
-
-    errdefer t.stopped.store(true, .release);
-
-    // disk tables merge task is different,
-    // it doesn't run infinitely, but runs a few merge cycles to process left overs
-    // from the previous launches
-    for (0..concurrency) |_| {
-        try t.startDiskTablesMerge(io, alloc);
-    }
-
-    try t.startMemTablesFlusher(io, alloc);
-    try t.startMemBlockFlusher(io, alloc);
-    try t.startCacheKeyInvalidator(io);
-
     return t;
 }
 
 pub fn createDir(io: Io, path: []const u8) void {
     fs.createDirAssert(io, path);
     fs.syncPathAndParentDir(io, path);
+}
+
+pub fn start(self: *IndexRecorder, io: Io, alloc: Allocator) !void {
+    // the allocator is different from http life cycle,
+    // but shared between all the background jobs
+    // TODO: find a better allocator, perhaps an arena with regular reset
+
+    self.stopped.store(false, .release);
+    errdefer self.stopped.store(true, .release);
+
+    // disk tables merge task is different,
+    // it doesn't run infinitely, but runs a few merge cycles to process left overs
+    // from the previous launches
+    for (0..self.concurrency) |_| {
+        try self.startDiskTablesMerge(io, alloc);
+    }
+
+    try self.startMemTablesFlusher(io, alloc);
+    try self.startMemBlockFlusher(io, alloc);
+    try self.startCacheKeyInvalidator(io);
 }
 
 // TODO: find an approach to make it never fail,
@@ -171,7 +174,12 @@ pub fn stop(self: *IndexRecorder, io: Io, alloc: Allocator) !void {
     self.stopped.store(true, .release);
     defer self.deinit(io, alloc);
 
-    try self.g.await(io);
+    // we ignore canceled erorr, we stop anyway
+    self.g.await(io) catch |err| {
+        switch (err) {
+            error.Canceled => {},
+        }
+    };
 
     try self.flushForce(io, alloc);
 }
@@ -882,8 +890,6 @@ test "flushMemEntries non-force respects flush deadline" {
 
     const recorder = try IndexRecorder.init(io, alloc, rootPath, runtime);
     defer recorder.deinit(io, alloc);
-    recorder.stopped.store(true, .release);
-    try recorder.g.await(io);
 
     var block = try MemBlock.init(alloc, 64);
     defer block.deinit(alloc);
@@ -921,8 +927,6 @@ test "mergeTables force single mem table creates disk table" {
 
     const recorder = try IndexRecorder.init(io, alloc, rootPath, runtime);
     defer recorder.deinit(io, alloc);
-    recorder.stopped.store(true, .release);
-    try recorder.g.await(io);
 
     const table = try createMemTableFromItems(io, alloc, &.{ "k1", "k2", "k3" });
     try recorder.memTables.append(alloc, table);
@@ -958,8 +962,6 @@ test "IndexRecorder add and reopen preserves item count" {
             try recorder.add(io, alloc, &batch);
         }
 
-        recorder.stopped.store(true, .release);
-        try recorder.g.await(io);
         try recorder.flushForce(io, alloc);
         try testing.expectEqual(@as(usize, 0), recorder.memTables.items.len);
         try testing.expect(recorder.diskTables.items.len > 0);
@@ -973,8 +975,6 @@ test "IndexRecorder add and reopen preserves item count" {
 
         const reopened = try IndexRecorder.init(io, alloc, rootPath, runtime);
         defer reopened.deinit(io, alloc);
-        reopened.stopped.store(true, .release);
-        try reopened.g.await(io);
         try testing.expect(reopened.diskTables.items.len > 0);
         try testing.expectEqual(@as(u64, 0), countMemItemsInRecorder(reopened));
         try testing.expectEqual(@as(u64, inserted), countDiskItemsInRecorder(reopened));
@@ -1036,8 +1036,6 @@ test "IndexRecorder concurrent add preserves item count" {
 
     try g.await(io);
 
-    recorder.stopped.store(true, .release);
-    try recorder.g.await(io);
     try recorder.flushForce(io, alloc);
 
     try testing.expectEqual(@as(u64, 0), countMemItemsInRecorder(recorder));
@@ -1203,9 +1201,6 @@ test "IndexRecorder large entries write to 3 shards" {
     try recorder.add(io, alloc, testEntries);
 
     try testing.expectEqual(totalEntries - countAdditionalEntries, recorder.blocksToFlush.items.len);
-
-    recorder.stopped.store(true, .release);
-    try recorder.g.await(io);
 
     try recorder.flushForce(io, alloc);
 


### PR DESCRIPTION
Added a start method, updated the stop method and deinit to match the previous behaviour. It works as before, makes no sense logically